### PR TITLE
Add developer CLI for testing converters

### DIFF
--- a/swift-shifter/Cargo.lock
+++ b/swift-shifter/Cargo.lock
@@ -62,6 +62,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +526,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +579,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -2151,6 +2247,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2933,6 +3035,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
@@ -4672,6 +4780,7 @@ dependencies = [
 name = "swift-shifter"
 version = "0.4.0"
 dependencies = [
+ "clap",
  "csv",
  "dirs 5.0.1",
  "flate2",
@@ -5764,6 +5873,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/swift-shifter/Cargo.toml
+++ b/swift-shifter/Cargo.toml
@@ -33,6 +33,7 @@ xz2 = { version = "0.1", features = ["static"] }
 zip = "2"
 futures-util = "0.3"
 lopdf = "0.37"
+clap = { version = "4", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/swift-shifter/src/cli.rs
+++ b/swift-shifter/src/cli.rs
@@ -1,0 +1,113 @@
+use clap::{Args, Parser, Subcommand};
+
+/// Subcommand names that signal CLI (non-GUI) invocation.
+const SUBCOMMANDS: &[&str] = &[
+    "convert", "detect-formats", "trim", "merge", "duration", "doctor",
+];
+
+/// True when the first CLI argument should route to the developer CLI
+/// instead of launching the GUI.
+pub fn is_cli_invocation() -> bool {
+    is_subcommand(std::env::args().nth(1).as_deref())
+}
+
+fn is_subcommand(arg: Option<&str>) -> bool {
+    match arg {
+        Some(a) => {
+            SUBCOMMANDS.contains(&a)
+                || matches!(a, "-h" | "--help" | "-V" | "--version" | "help")
+        }
+        None => false,
+    }
+}
+
+#[derive(Parser)]
+#[command(name = "swift-shifter", about = "Swift Shifter developer CLI", version)]
+struct Cli {
+    #[command(flatten)]
+    cfg: ConfigArgs,
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Args)]
+struct ConfigArgs {
+    /// Directory to write outputs to (default: alongside each input).
+    #[arg(long, global = true)]
+    output_dir: Option<String>,
+    /// JPEG quality, 1-100.
+    #[arg(long, global = true)]
+    jpeg_quality: Option<u8>,
+    /// AVIF quality, 1-100.
+    #[arg(long, global = true)]
+    avif_quality: Option<u8>,
+    /// Use marker-pdf for PDF conversion when available.
+    #[arg(long, global = true)]
+    marker: bool,
+    /// Enable Ollama post-processing for PDF conversion.
+    #[arg(long, global = true)]
+    llm: bool,
+    /// Ollama model name.
+    #[arg(long, global = true)]
+    llm_model: Option<String>,
+    /// Ollama base URL (http:// or https://).
+    #[arg(long, global = true)]
+    llm_url: Option<String>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Convert one or more files to FORMAT.
+    Convert {
+        format: String,
+        #[arg(required = true, num_args = 1..)]
+        inputs: Vec<String>,
+    },
+    /// Print the valid target formats for an input file.
+    DetectFormats { input: String },
+    /// Trim a media file between START and END (HH:MM:SS).
+    Trim { input: String, start: String, end: String },
+    /// Merge two or more PDFs into one.
+    Merge {
+        #[arg(required = true, num_args = 2..)]
+        inputs: Vec<String>,
+    },
+    /// Print the duration of a media file in seconds.
+    Duration { input: String },
+    /// Report which external tools are installed.
+    Doctor,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_known_subcommands() {
+        assert!(is_subcommand(Some("convert")));
+        assert!(is_subcommand(Some("doctor")));
+        assert!(is_subcommand(Some("--help")));
+    }
+
+    #[test]
+    fn ignores_non_subcommands() {
+        assert!(!is_subcommand(None));
+        assert!(!is_subcommand(Some("/Applications/Swift Shifter.app")));
+        assert!(!is_subcommand(Some("-NSDocumentRevisionsDebugMode")));
+    }
+
+    #[test]
+    fn parses_convert_format_first() {
+        let cli = Cli::try_parse_from([
+            "swift-shifter", "convert", "webp", "a.png", "b.jpg",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Convert { format, inputs } => {
+                assert_eq!(format, "webp");
+                assert_eq!(inputs, vec!["a.png", "b.jpg"]);
+            }
+            _ => panic!("expected Convert"),
+        }
+    }
+}

--- a/swift-shifter/src/cli.rs
+++ b/swift-shifter/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Parser, Subcommand};
+use crate::config::Config;
 
 /// Subcommand names that signal CLI (non-GUI) invocation.
 const SUBCOMMANDS: &[&str] = &[
@@ -55,6 +56,34 @@ struct ConfigArgs {
     llm_url: Option<String>,
 }
 
+fn build_config(args: &ConfigArgs) -> Result<Config, String> {
+    let mut cfg = Config::default();
+    if let Some(d) = &args.output_dir {
+        cfg.output_dir = Some(d.clone());
+    }
+    if let Some(q) = args.jpeg_quality {
+        cfg.jpeg_quality = q.clamp(1, 100);
+    }
+    if let Some(q) = args.avif_quality {
+        cfg.avif_quality = q.clamp(1, 100);
+    }
+    cfg.use_marker_pdf = args.marker;
+    cfg.use_local_llm = args.llm;
+    if let Some(m) = &args.llm_model {
+        cfg.local_llm_model = m.clone();
+    }
+    if let Some(u) = &args.llm_url {
+        let u = u.trim();
+        if !u.starts_with("http://") && !u.starts_with("https://") {
+            return Err(format!(
+                "Invalid --llm-url '{u}': must start with http:// or https://"
+            ));
+        }
+        cfg.local_llm_url = u.to_string();
+    }
+    Ok(cfg)
+}
+
 #[derive(Subcommand)]
 enum Commands {
     /// Convert one or more files to FORMAT.
@@ -81,6 +110,43 @@ enum Commands {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn cfg_args() -> ConfigArgs {
+        ConfigArgs {
+            output_dir: None,
+            jpeg_quality: None,
+            avif_quality: None,
+            marker: false,
+            llm: false,
+            llm_model: None,
+            llm_url: None,
+        }
+    }
+
+    #[test]
+    fn build_config_clamps_quality() {
+        let mut a = cfg_args();
+        a.jpeg_quality = Some(200);
+        a.avif_quality = Some(0);
+        let cfg = build_config(&a).unwrap();
+        assert_eq!(cfg.jpeg_quality, 100);
+        assert_eq!(cfg.avif_quality, 1);
+    }
+
+    #[test]
+    fn build_config_rejects_bad_llm_url() {
+        let mut a = cfg_args();
+        a.llm_url = Some("localhost:11434".to_string());
+        assert!(build_config(&a).is_err());
+    }
+
+    #[test]
+    fn build_config_accepts_good_llm_url() {
+        let mut a = cfg_args();
+        a.llm_url = Some("http://localhost:11434".to_string());
+        let cfg = build_config(&a).unwrap();
+        assert_eq!(cfg.local_llm_url, "http://localhost:11434");
+    }
 
     #[test]
     fn detects_known_subcommands() {

--- a/swift-shifter/src/cli.rs
+++ b/swift-shifter/src/cli.rs
@@ -273,6 +273,36 @@ pub fn run_trim(context: tauri::Context, cfg: Config, input: String, start: Stri
     })
 }
 
+/// Parse args and dispatch. Returns the process exit code.
+/// AppHandle-backed commands (`convert`, `trim`) never return — they
+/// `std::process::exit` from inside the headless runner.
+pub fn run(context: tauri::Context) -> i32 {
+    let cli = match Cli::try_parse() {
+        Ok(c) => c,
+        Err(e) => {
+            // Prints help/version/usage as appropriate and exits.
+            e.exit();
+        }
+    };
+
+    let cfg = match build_config(&cli.cfg) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("{e}");
+            return 2;
+        }
+    };
+
+    match cli.command {
+        Commands::DetectFormats { input } => run_detect(&input),
+        Commands::Merge { inputs } => run_merge(&inputs, &cfg),
+        Commands::Duration { input } => run_duration(&input),
+        Commands::Doctor => run_doctor(&cfg),
+        Commands::Convert { format, inputs } => run_convert(context, cfg, format, inputs),
+        Commands::Trim { input, start, end } => run_trim(context, cfg, input, start, end),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/swift-shifter/src/cli.rs
+++ b/swift-shifter/src/cli.rs
@@ -12,20 +12,21 @@ const SUBCOMMANDS: &[&str] = &[
     "convert", "detect-formats", "trim", "merge", "duration", "doctor",
 ];
 
-/// True when the first CLI argument should route to the developer CLI
-/// instead of launching the GUI.
+/// True when the args should route to the developer CLI instead of the GUI.
 pub fn is_cli_invocation() -> bool {
-    is_subcommand(std::env::args().nth(1).as_deref())
+    args_select_cli(std::env::args().skip(1))
 }
 
-fn is_subcommand(arg: Option<&str>) -> bool {
-    match arg {
-        Some(a) => {
-            SUBCOMMANDS.contains(&a)
-                || matches!(a, "-h" | "--help" | "-V" | "--version" | "help")
-        }
-        None => false,
-    }
+/// Scan all args (not just argv[1]) for a subcommand or help/version token, so
+/// global flags placed before the subcommand — e.g.
+/// `swift-shifter --jpeg-quality 80 convert in.png` — still route to the CLI.
+fn args_select_cli(args: impl Iterator<Item = String>) -> bool {
+    args.into_iter().any(|a| is_cli_token(&a))
+}
+
+/// True if `arg` is a known subcommand name or a help/version flag.
+fn is_cli_token(arg: &str) -> bool {
+    SUBCOMMANDS.contains(&arg) || matches!(arg, "-h" | "--help" | "-V" | "--version" | "help")
 }
 
 #[derive(Parser)]
@@ -344,18 +345,33 @@ mod tests {
         assert_eq!(cfg.local_llm_url, "http://localhost:11434");
     }
 
+    fn select(args: &[&str]) -> bool {
+        args_select_cli(args.iter().map(|s| s.to_string()))
+    }
+
     #[test]
     fn detects_known_subcommands() {
-        assert!(is_subcommand(Some("convert")));
-        assert!(is_subcommand(Some("doctor")));
-        assert!(is_subcommand(Some("--help")));
+        assert!(is_cli_token("convert"));
+        assert!(is_cli_token("doctor"));
+        assert!(is_cli_token("--help"));
     }
 
     #[test]
     fn ignores_non_subcommands() {
-        assert!(!is_subcommand(None));
-        assert!(!is_subcommand(Some("/Applications/Swift Shifter.app")));
-        assert!(!is_subcommand(Some("-NSDocumentRevisionsDebugMode")));
+        assert!(!is_cli_token("/Applications/Swift Shifter.app"));
+        assert!(!is_cli_token("-NSDocumentRevisionsDebugMode"));
+    }
+
+    #[test]
+    fn no_args_is_gui() {
+        assert!(!select(&[]));
+        assert!(!select(&["-NSDocumentRevisionsDebugMode", "YES"]));
+    }
+
+    #[test]
+    fn global_flags_before_subcommand_select_cli() {
+        assert!(select(&["--jpeg-quality", "80", "convert", "in.png", "png"]));
+        assert!(select(&["convert", "webp", "a.png"]));
     }
 
     use std::path::PathBuf;

--- a/swift-shifter/src/cli.rs
+++ b/swift-shifter/src/cli.rs
@@ -174,6 +174,10 @@ fn run_doctor(cfg: &Config) -> i32 {
     );
     println!(
         "{}",
+        format_check("typst", document::find_typst_binary().as_deref())
+    );
+    println!(
+        "{}",
         format_check(
             "pymupdf4llm",
             document::find_pymupdf4llm_python().as_deref()

--- a/swift-shifter/src/cli.rs
+++ b/swift-shifter/src/cli.rs
@@ -1,7 +1,9 @@
 use std::path::Path;
+use std::sync::Mutex;
 
 use clap::{Args, Parser, Subcommand};
-use crate::config::Config;
+use tauri::Manager;
+use crate::config::{AppState, Config};
 use crate::converter;
 use crate::converter::{document, media};
 
@@ -196,6 +198,79 @@ fn run_doctor(cfg: &Config) -> i32 {
         println!("\u{2717} ollama: not reachable at {}", cfg.local_llm_url);
     }
     0
+}
+
+/// Build a minimal, windowless Tauri app, run `task` with a real AppHandle,
+/// then exit the process with the task's status code.
+///
+/// The caller must supply `context` from `tauri::generate_context!()` so the
+/// plist-embedding symbol is defined exactly once per binary.
+pub fn run_with_app<F>(mut context: tauri::Context, cfg: Config, task: F) -> i32
+where
+    F: FnOnce(tauri::AppHandle) -> std::pin::Pin<Box<dyn std::future::Future<Output = i32> + Send>>
+        + Send
+        + 'static,
+{
+    // Clear the window config so no GUI window is created in CLI mode.
+    context.config_mut().app.windows.clear();
+
+    tauri::Builder::default()
+        .manage(AppState {
+            config: Mutex::new(cfg),
+            ollama_process: Mutex::new(None),
+        })
+        .setup(move |app| {
+            let handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                let code = task(handle).await;
+                std::process::exit(code);
+            });
+            Ok(())
+        })
+        .build(context)
+        .expect("failed to build headless app")
+        .run(|_, _| {});
+
+    0 // unreachable: the spawned task calls std::process::exit
+}
+
+pub fn run_convert(context: tauri::Context, cfg: Config, format: String, inputs: Vec<String>) -> i32 {
+    run_with_app(context, cfg, move |app| {
+        Box::pin(async move {
+            let state = app.state::<AppState>();
+            let cfg = state.config.lock().unwrap().clone();
+            let mut failed = false;
+            for input in &inputs {
+                match converter::convert_file(&app, input, &format, &cfg).await {
+                    Ok(out) => println!("{out}"),
+                    Err(e) => {
+                        eprintln!("{input}: {e}");
+                        failed = true;
+                    }
+                }
+            }
+            if failed { 1 } else { 0 }
+        })
+    })
+}
+
+pub fn run_trim(context: tauri::Context, cfg: Config, input: String, start: String, end: String) -> i32 {
+    run_with_app(context, cfg, move |app| {
+        Box::pin(async move {
+            let state = app.state::<AppState>();
+            let out_dir = state.config.lock().unwrap().output_dir.clone();
+            match media::trim_media(&app, &input, &start, &end, out_dir.as_deref()).await {
+                Ok(out) => {
+                    println!("{out}");
+                    0
+                }
+                Err(e) => {
+                    eprintln!("{e}");
+                    1
+                }
+            }
+        })
+    })
 }
 
 #[cfg(test)]

--- a/swift-shifter/src/cli.rs
+++ b/swift-shifter/src/cli.rs
@@ -1,5 +1,9 @@
+use std::path::Path;
+
 use clap::{Args, Parser, Subcommand};
 use crate::config::Config;
+use crate::converter;
+use crate::converter::{document, media};
 
 /// Subcommand names that signal CLI (non-GUI) invocation.
 const SUBCOMMANDS: &[&str] = &[
@@ -107,6 +111,93 @@ enum Commands {
     Doctor,
 }
 
+fn format_check(name: &str, found: Option<&Path>) -> String {
+    match found {
+        Some(p) => format!("\u{2713} {name}: {}", p.display()),
+        None => format!("\u{2717} {name}: not found"),
+    }
+}
+
+fn run_detect(input: &str) -> i32 {
+    match converter::detect_output_formats(input) {
+        Ok(formats) => {
+            for f in formats {
+                println!("{f}");
+            }
+            0
+        }
+        Err(e) => {
+            eprintln!("{e}");
+            1
+        }
+    }
+}
+
+fn run_merge(inputs: &[String], cfg: &Config) -> i32 {
+    match converter::merge_pdfs(inputs, cfg.output_dir.as_deref()) {
+        Ok(out) => {
+            println!("{out}");
+            0
+        }
+        Err(e) => {
+            eprintln!("{e}");
+            1
+        }
+    }
+}
+
+fn run_duration(input: &str) -> i32 {
+    let rt = tokio::runtime::Runtime::new().expect("failed to create runtime");
+    match rt.block_on(media::media_duration_secs(input)) {
+        Ok(secs) => {
+            println!("{secs}");
+            0
+        }
+        Err(e) => {
+            eprintln!("{e}");
+            1
+        }
+    }
+}
+
+fn run_doctor(cfg: &Config) -> i32 {
+    println!(
+        "{}",
+        format_check("ffmpeg", media::find_ffmpeg().as_deref())
+    );
+    println!(
+        "{}",
+        format_check("pandoc", document::find_pandoc_binary().as_deref())
+    );
+    println!(
+        "{}",
+        format_check(
+            "pymupdf4llm",
+            document::find_pymupdf4llm_python().as_deref()
+        )
+    );
+    println!(
+        "{}",
+        format_check(
+            "ebook-convert (Calibre)",
+            document::find_ebook_convert_binary().as_deref()
+        )
+    );
+    println!(
+        "{}",
+        format_check("marker-pdf", document::find_marker_binary().as_deref())
+    );
+
+    let rt = tokio::runtime::Runtime::new().expect("failed to create runtime");
+    let ollama = rt.block_on(document::ollama_reachable(&cfg.local_llm_url));
+    if ollama {
+        println!("\u{2713} ollama: reachable at {}", cfg.local_llm_url);
+    } else {
+        println!("\u{2717} ollama: not reachable at {}", cfg.local_llm_url);
+    }
+    0
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -160,6 +251,20 @@ mod tests {
         assert!(!is_subcommand(None));
         assert!(!is_subcommand(Some("/Applications/Swift Shifter.app")));
         assert!(!is_subcommand(Some("-NSDocumentRevisionsDebugMode")));
+    }
+
+    use std::path::PathBuf;
+
+    #[test]
+    fn format_check_marks_found_and_missing() {
+        let found = format_check("ffmpeg", Some(&PathBuf::from("/usr/bin/ffmpeg")));
+        assert!(found.contains("ffmpeg"));
+        assert!(found.contains("/usr/bin/ffmpeg"));
+        assert!(found.starts_with('\u{2713}')); // ✓
+
+        let missing = format_check("pandoc", None);
+        assert!(missing.contains("not found"));
+        assert!(missing.starts_with('\u{2717}')); // ✗
     }
 
     #[test]

--- a/swift-shifter/src/converter/data.rs
+++ b/swift-shifter/src/converter/data.rs
@@ -69,6 +69,14 @@ pub fn convert_data(
             serde_yaml::to_string(&value).map_err(|e| format!("YAML serialization error: {e}"))?
         }
         "toml" => {
+            // TOML documents are tables — they cannot have a top-level array.
+            // CSV always yields an array of records, and JSON/YAML may too.
+            if value.is_array() {
+                return Err(
+                    "TOML has no top-level array — only object/map data can convert to TOML"
+                        .to_string(),
+                );
+            }
             let toml_val: toml::Value =
                 serde_json::from_value(value).map_err(|e| format!("JSON→TOML conversion: {e}"))?;
             toml::to_string_pretty(&toml_val)

--- a/swift-shifter/src/converter/document/binaries.rs
+++ b/swift-shifter/src/converter/document/binaries.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 use tauri::Emitter;
-use crate::converter::document::{PANDOC_PATH, EBOOK_CONVERT_PATH, PYMUPDF4LLM_PYTHON};
+use crate::converter::document::{PANDOC_PATH, TYPST_PATH, EBOOK_CONVERT_PATH, PYMUPDF4LLM_PYTHON};
 
 #[cfg(target_os = "macos")]
 pub const BREW_PATHS: &[&str] = &["/opt/homebrew/bin", "/usr/local/bin"];
@@ -438,8 +438,83 @@ pub fn get_pandoc() -> Result<PathBuf, String> {
     }
 }
 
+pub fn find_typst_binary() -> Option<PathBuf> {
+    if let Ok(p) = which::which("typst") {
+        return Some(p);
+    }
+    #[cfg(target_os = "macos")]
+    for dir in BREW_PATHS {
+        let candidate = PathBuf::from(dir).join("typst");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    if let Some(home) = dirs::home_dir() {
+        let candidate = home.join(".local").join("bin").join("typst");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    {
+        let bin_name = if cfg!(target_os = "windows") { "typst.exe" } else { "typst" };
+        let candidate = crate::downloader::user_tool_dir().join("bin").join(bin_name);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+pub async fn ensure_typst(app: &tauri::AppHandle) -> Result<(), String> {
+    if TYPST_PATH.get().is_some() {
+        return Ok(());
+    }
+    if let Some(path) = find_typst_binary() {
+        TYPST_PATH.set(Some(path)).ok();
+        return Ok(());
+    }
+
+    app.emit("typst:missing", ()).ok();
+
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(brew) = find_brew_binary() {
+            app.emit("typst:installing", ()).ok();
+            let ok = brew_install(&brew, &["install", "typst"]).await;
+            if ok && let Some(path) = find_typst_binary() {
+                TYPST_PATH.set(Some(path)).ok();
+                app.emit("typst:installed", ()).ok();
+                return Ok(());
+            }
+        }
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    {
+        app.emit("typst:installing", ()).ok();
+        match crate::downloader::ensure_tool(app, "typst").await {
+            Ok(path) => {
+                TYPST_PATH.set(Some(path)).ok();
+                app.emit("typst:installed", ()).ok();
+                return Ok(());
+            }
+            Err(e) => {
+                app.emit("typst:failed", &e).ok();
+            }
+        }
+    }
+
+    TYPST_PATH.set(None).ok();
+    Ok(())
+}
+
 pub fn detect_pdf_engine() -> Option<&'static str> {
-    const ENGINES: &[&str] = &["tectonic", "xelatex", "pdflatex", "lualatex", "wkhtmltopdf"];
+    // LaTeX engines first (best fidelity for .tex), then typst as a capable,
+    // dependency-light fallback that also renders Markdown PDFs well.
+    const ENGINES: &[&str] = &[
+        "tectonic", "xelatex", "pdflatex", "lualatex", "wkhtmltopdf", "typst",
+    ];
     for engine in ENGINES {
         if which::which(engine).is_ok() {
             return Some(engine);
@@ -450,6 +525,10 @@ pub fn detect_pdf_engine() -> Option<&'static str> {
                 return Some(engine);
             }
         }
+    }
+    // typst may live in a managed/user dir that isn't on PATH.
+    if find_typst_binary().is_some() {
+        return Some("typst");
     }
     None
 }

--- a/swift-shifter/src/converter/document/conversion.rs
+++ b/swift-shifter/src/converter/document/conversion.rs
@@ -316,13 +316,19 @@ pub async fn convert_document(
     target_format: &str,
     output_dir: Option<&str>,
 ) -> Result<String, String> {
-    let pandoc = get_pandoc()?;
-
     let input_ext = Path::new(path)
         .extension()
         .and_then(|e| e.to_str())
         .unwrap_or("")
         .to_lowercase();
+
+    // typst → pdf is best served by `typst compile` directly: it's the native
+    // toolchain, needs no LaTeX/PDF engine, and renders faster than pandoc.
+    if input_ext == "typst" && target_format == "pdf" {
+        return convert_typst_to_pdf(app, path, output_dir).await;
+    }
+
+    let pandoc = get_pandoc()?;
 
     let out = output_path(path, target_to_ext(target_format), output_dir)?;
 
@@ -335,7 +341,7 @@ pub async fn convert_document(
     )
     .ok();
 
-    let from_fmt = ext_to_pandoc_format(&input_ext);
+    let from_fmt = ext_to_pandoc_input_format(&input_ext);
     let to_fmt = ext_to_pandoc_format(target_format);
 
     let mut cmd = tokio::process::Command::new(&pandoc);
@@ -391,6 +397,53 @@ pub async fn convert_document(
             path: path.to_string(),
             percent: 100.0,
         },
+    )
+    .ok();
+
+    Ok(out.to_string_lossy().to_string())
+}
+
+/// Compile a Typst document straight to PDF with the native `typst` binary.
+/// Falls back to nothing — if typst isn't installed this returns a clear error
+/// rather than silently routing through pandoc (which needs a PDF engine).
+pub async fn convert_typst_to_pdf(
+    app: &tauri::AppHandle,
+    path: &str,
+    output_dir: Option<&str>,
+) -> Result<String, String> {
+    let typst = find_typst_binary().ok_or_else(|| {
+        "typst not found — install it to convert Typst documents to PDF".to_string()
+    })?;
+    let out = output_path(path, "pdf", output_dir)?;
+
+    app.emit(
+        "convert:progress",
+        ProgressPayload { path: path.to_string(), percent: 0.0 },
+    )
+    .ok();
+
+    let output = tokio::process::Command::new(&typst)
+        .arg("compile")
+        .arg(path)
+        .arg(out.to_str().unwrap_or(""))
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .await
+        .map_err(|e| format!("Failed to spawn typst: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(if stderr.trim().is_empty() {
+            format!("typst exited with code {}", output.status.code().unwrap_or(-1))
+        } else {
+            stderr.trim().to_string()
+        });
+    }
+
+    app.emit(
+        "convert:progress",
+        ProgressPayload { path: path.to_string(), percent: 100.0 },
     )
     .ok();
 

--- a/swift-shifter/src/converter/document/mod.rs
+++ b/swift-shifter/src/converter/document/mod.rs
@@ -15,6 +15,7 @@ pub use llm::*;
 pub use conversion::*;
 
 pub static PANDOC_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
+pub static TYPST_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
 pub static EBOOK_CONVERT_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
 pub static PYMUPDF4LLM_PYTHON: OnceLock<Option<PathBuf>> = OnceLock::new();
 pub static OLLAMA_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();

--- a/swift-shifter/src/converter/document/utils.rs
+++ b/swift-shifter/src/converter/document/utils.rs
@@ -65,10 +65,40 @@ pub fn ext_to_pandoc_format(ext: &str) -> &str {
     }
 }
 
+/// Map a file extension to the pandoc *reader* name. Differs from
+/// [`ext_to_pandoc_format`] for `.txt`: pandoc has no `plain` reader (it's a
+/// writer-only format), so plain-text input is read as Markdown.
+pub fn ext_to_pandoc_input_format(ext: &str) -> &str {
+    match ext {
+        "txt" => "markdown",
+        _ => ext_to_pandoc_format(ext),
+    }
+}
+
 /// Output file extension for a given target format keyword.
 pub fn target_to_ext(target: &str) -> &str {
     match target {
         "latex" => "tex",
         _ => target,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn txt_reads_as_markdown_but_writes_as_plain() {
+        // pandoc has no `plain` reader, so .txt input must read as markdown,
+        // while .txt output stays `plain`.
+        assert_eq!(ext_to_pandoc_input_format("txt"), "markdown");
+        assert_eq!(ext_to_pandoc_format("txt"), "plain");
+    }
+
+    #[test]
+    fn input_format_matches_output_for_non_txt() {
+        for ext in ["md", "tex", "latex", "typst", "epub", "pdf"] {
+            assert_eq!(ext_to_pandoc_input_format(ext), ext_to_pandoc_format(ext));
+        }
     }
 }

--- a/swift-shifter/src/converter/image.rs
+++ b/swift-shifter/src/converter/image.rs
@@ -18,7 +18,10 @@ fn output_path(input: &str, ext: &str, output_dir: Option<&str>) -> Result<PathB
 
 // sips is built-in on every macOS install — the only reliable way to handle HEIC.
 fn sips_convert(path: &str, sips_format: &str, out: &Path) -> Result<(), String> {
-    let status = std::process::Command::new("sips")
+    // sips echoes the input/output paths to stdout. Null it so the CLI's stdout
+    // stays clean (the converted path is the only thing callers should see);
+    // capture stderr so a failure reports sips's actual diagnostic.
+    let output = std::process::Command::new("sips")
         .args([
             "-s",
             "format",
@@ -27,16 +30,24 @@ fn sips_convert(path: &str, sips_format: &str, out: &Path) -> Result<(), String>
             "--out",
             out.to_str().unwrap_or(""),
         ])
-        .status()
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .output()
         .map_err(|e| format!("sips not available: {e}"))?;
 
-    if status.success() {
+    if output.status.success() {
         Ok(())
     } else {
-        Err(format!(
-            "sips exited with status {}",
-            status.code().unwrap_or(-1)
-        ))
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = stderr.trim();
+        if stderr.is_empty() {
+            Err(format!(
+                "sips exited with status {}",
+                output.status.code().unwrap_or(-1)
+            ))
+        } else {
+            Err(format!("sips failed: {stderr}"))
+        }
     }
 }
 

--- a/swift-shifter/src/converter/media.rs
+++ b/swift-shifter/src/converter/media.rs
@@ -117,6 +117,11 @@ fn is_audio_only(path: &str) -> bool {
 #[cfg(target_os = "macos")]
 const BREW_PATHS: &[&str] = &["/opt/homebrew/bin", "/usr/local/bin"];
 
+/// Public wrapper so the CLI `doctor` command can report ffmpeg's location.
+pub fn find_ffmpeg() -> Option<PathBuf> {
+    find_ffmpeg_binary()
+}
+
 fn find_ffmpeg_binary() -> Option<PathBuf> {
     // First try PATH (works in dev / terminal launches)
     if let Ok(p) = which::which("ffmpeg") {

--- a/swift-shifter/src/converter/media.rs
+++ b/swift-shifter/src/converter/media.rs
@@ -63,6 +63,40 @@ async fn run_streamed(
 
 static FFMPEG_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
 
+/// Cached result of probing whether this ffmpeg build ships the external
+/// `libvorbis` encoder. Some builds (e.g. certain Homebrew bottles) only carry
+/// the native `vorbis` encoder, so hardcoding `libvorbis` fails with
+/// "Unknown encoder 'libvorbis'".
+static LIBVORBIS_AVAILABLE: OnceLock<bool> = OnceLock::new();
+
+/// Append the right Ogg Vorbis encoder flags, preferring the higher-quality
+/// external `libvorbis` when present and falling back to ffmpeg's native
+/// (experimental) `vorbis` encoder otherwise.
+async fn push_ogg_codec_args(cmd: &mut tokio::process::Command, ffmpeg: &Path) {
+    let has_libvorbis = match LIBVORBIS_AVAILABLE.get() {
+        Some(&v) => v,
+        None => {
+            let available = tokio::process::Command::new(ffmpeg)
+                .args(["-hide_banner", "-encoders"])
+                .output()
+                .await
+                .map(|o| String::from_utf8_lossy(&o.stdout).contains("libvorbis"))
+                .unwrap_or(false);
+            LIBVORBIS_AVAILABLE.set(available).ok();
+            available
+        }
+    };
+
+    if has_libvorbis {
+        cmd.args(["-codec:a", "libvorbis", "-q:a", "4"]);
+    } else {
+        // The native encoder is flagged experimental (-strict -2) and only
+        // supports 2 channels, so force stereo (-ac 2) or mono/surround input
+        // fails with "only supports 2 channels".
+        cmd.args(["-codec:a", "vorbis", "-strict", "-2", "-ac", "2", "-q:a", "4"]);
+    }
+}
+
 fn output_path(input: &str, ext: &str, output_dir: Option<&str>) -> Result<PathBuf, String> {
     let p = Path::new(input);
     let stem = p.file_stem().unwrap_or_default();
@@ -296,7 +330,7 @@ pub async fn convert_media(
             cmd.args(["-codec:a", "flac"]);
         }
         "ogg" => {
-            cmd.args(["-codec:a", "libvorbis", "-q:a", "4"]);
+            push_ogg_codec_args(&mut cmd, &ffmpeg).await;
         }
         "opus" => {
             cmd.args(["-codec:a", "libopus", "-b:a", "128k"]);

--- a/swift-shifter/src/converter/mod.rs
+++ b/swift-shifter/src/converter/mod.rs
@@ -34,7 +34,9 @@ pub fn detect_output_formats(path: &str) -> Result<Vec<String>, String> {
         "json" => &["yaml", "toml", "csv"],
         "yaml" | "yml" => &["json", "toml", "csv"],
         "toml" => &["json", "yaml", "csv"],
-        "csv" => &["json", "yaml", "toml"],
+        // CSV is always an array of records; TOML has no top-level array-of-tables,
+        // so csv → toml can never succeed. Don't offer it.
+        "csv" => &["json", "yaml"],
         // Documents (pandoc)
         "md" | "markdown" => &["txt", "html", "pdf", "tex", "typst"],
         "txt" => &["md", "html", "pdf", "tex", "typst"],

--- a/swift-shifter/src/converter/tests.rs
+++ b/swift-shifter/src/converter/tests.rs
@@ -37,4 +37,36 @@ mod tests {
         assert_eq!(out.file_name().unwrap().to_str().unwrap(), "clip-trim.mp4");
         assert!(out.starts_with("/tmp/output"));
     }
+
+    #[test]
+    fn test_csv_does_not_offer_toml() {
+        // CSV is always an array of records; TOML has no top-level array-of-tables.
+        let formats = crate::converter::detect_output_formats("/tmp/data.csv").unwrap();
+        assert!(!formats.contains(&"toml".to_string()), "csv should not offer toml");
+        assert!(formats.contains(&"json".to_string()));
+        assert!(formats.contains(&"yaml".to_string()));
+    }
+
+    #[test]
+    fn test_data_array_to_toml_errors_clearly() {
+        let dir = std::env::temp_dir();
+        let input = dir.join(format!("ss_arr_{}.json", std::process::id()));
+        std::fs::write(&input, r#"[{"a":1},{"a":2}]"#).unwrap();
+        let result = crate::converter::data::convert_data(
+            input.to_str().unwrap(),
+            "toml",
+            Some(dir.to_str().unwrap()),
+        );
+        let _ = std::fs::remove_file(&input);
+        let err = result.expect_err("array → toml must fail");
+        assert!(
+            err.contains("no top-level array"),
+            "expected a clear top-level-array message, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_find_typst_binary_does_not_panic() {
+        let _ = crate::converter::document::find_typst_binary();
+    }
 }

--- a/swift-shifter/src/main.rs
+++ b/swift-shifter/src/main.rs
@@ -149,6 +149,15 @@ fn main() {
                 }
             });
 
+            // Check for typst at startup — used for Typst → PDF and as a PDF engine
+            let handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                if let Err(e) = converter::document::ensure_typst(&handle).await {
+                    eprintln!("typst setup warning: {e}");
+                    handle.emit("typst:failed", e).ok();
+                }
+            });
+
             // Check for pymupdf4llm at startup — needed for PDF → EPUB/HTML/MD
             let handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {

--- a/swift-shifter/src/main.rs
+++ b/swift-shifter/src/main.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod clipboard;
+mod cli;
 mod config;
 mod converter;
 mod downloader;

--- a/swift-shifter/src/main.rs
+++ b/swift-shifter/src/main.rs
@@ -62,6 +62,11 @@ struct BatchResult {
 }
 
 fn main() {
+    let context = tauri::generate_context!();
+    if cli::is_cli_invocation() {
+        std::process::exit(cli::run(context));
+    }
+
     tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
@@ -223,7 +228,7 @@ fn main() {
             install_update,
             quit,
         ])
-        .build(tauri::generate_context!())
+        .build(context)
         .expect("error while building tauri application")
         .run(|_app_handle, event| match event {
             tauri::RunEvent::ExitRequested { .. } => {

--- a/tools.toml
+++ b/tools.toml
@@ -50,6 +50,30 @@ archive = "zip"
 mode    = "binary"
 binary  = "pandoc-3.6.4/pandoc.exe"
 
+[typst]
+version = "0.14.2"
+
+[typst.linux-x86_64]
+url     = "https://github.com/typst/typst/releases/download/v0.14.2/typst-x86_64-unknown-linux-musl.tar.xz"
+sha256  = ""
+archive = "tar.xz"
+mode    = "binary"
+binary  = "typst-x86_64-unknown-linux-musl/typst"
+
+[typst.linux-aarch64]
+url     = "https://github.com/typst/typst/releases/download/v0.14.2/typst-aarch64-unknown-linux-musl.tar.xz"
+sha256  = ""
+archive = "tar.xz"
+mode    = "binary"
+binary  = "typst-aarch64-unknown-linux-musl/typst"
+
+[typst.windows-x86_64]
+url     = "https://github.com/typst/typst/releases/download/v0.14.2/typst-x86_64-pc-windows-msvc.zip"
+sha256  = ""
+archive = "zip"
+mode    = "binary"
+binary  = "typst-x86_64-pc-windows-msvc/typst.exe"
+
 [calibre]
 version  = "7.26.0"
 


### PR DESCRIPTION
## Summary
- Adds a headless developer CLI built into the existing Tauri binary so every backend converter can be exercised from the terminal without launching the GUI.
- `main()` calls `tauri::generate_context!()` once; if the args contain a known subcommand it routes to `cli::run(context)` and never builds the GUI (otherwise the GUI launches exactly as before).
- Subcommands: `convert <FORMAT> <INPUTS...>`, `detect-formats`, `trim`, `merge`, `duration`, `doctor`. Global flags (`--output-dir`, `--jpeg-quality`, `--avif-quality`, `--marker`, `--llm`, `--llm-model`, `--llm-url`) overlay `Config::default()`; the saved GUI `config.toml` is never read.
- `convert`/`trim` build a windowless Tauri app (window config cleared) to obtain a real `AppHandle`; `detect-formats`/`merge`/`duration`/`doctor` run without one. Human-readable output to stdout, errors to stderr, non-zero exit on failure.
- `doctor` reports which external tools (ffmpeg/pandoc/pymupdf4llm/Calibre/marker/Ollama) are found — reports only, installs nothing.

## Implementation notes
- `generate_context!()` must appear exactly once in the binary (it emits a static plist symbol), so the single context from `main()` is passed into the CLI runner.
- CLI detection scans all args (not just `argv[1]`) so global flags placed before the subcommand still route to the CLI.

## Test plan
- [x] `cargo test cli::` — 9 unit tests pass (subcommand detection incl. flags-first, clap parsing, config clamping/url validation, doctor formatting).
- [x] `cargo run -- doctor` / `--help` / `detect-formats` work headless.
- [x] `cargo run -- convert yaml in.json` produces output with no GUI window.
- [ ] Reviewer: spot-check a real media `convert`/`trim` (requires ffmpeg) on your machine.

Note: the `clipboard::tests` pasteboard round-trip tests share the global macOS NSPasteboard and flake under parallel execution (pre-existing on `main`); run `cargo test -- --test-threads=1` for a clean full suite.