### PR TITLE
Multi-hop universal conversion via a format graph

### DIFF
--- a/swift-shifter/Cargo.toml
+++ b/swift-shifter/Cargo.toml
@@ -34,9 +34,9 @@ zip = "2"
 futures-util = "0.3"
 lopdf = "0.37"
 clap = { version = "4", features = ["derive"] }
+tempfile = "3"
 
 [dev-dependencies]
-tempfile = "3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"

--- a/swift-shifter/src/converter/graph.rs
+++ b/swift-shifter/src/converter/graph.rs
@@ -28,8 +28,6 @@ impl EdgeCond {
 pub struct Edge {
     pub from: &'static str,
     pub to: &'static str,
-    // cost is read by the Dijkstra path-finder in Task 3; suppress dead_code until then.
-    #[allow(dead_code)]
     pub cost: u32,
     pub cond: EdgeCond,
 }
@@ -148,4 +146,159 @@ pub fn direct_targets(from_ext: &str) -> Vec<String> {
         .filter(|e| e.from == from && e.cond.satisfied())
         .map(|e| e.to.to_string())
         .collect()
+}
+
+use std::collections::{BinaryHeap, HashMap};
+
+/// Which converter performs a single (from,to) hop. Mirrors the dispatch in
+/// `converter::run_single_hop`. `route_hop` returns `Some` iff the pair is
+/// handled — making it the shared coverage check for the property test.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Hop {
+    ImageRaster,    // image -> pdf (document::convert_image_to_pdf)
+    ImageToAvif,
+    ImageToHeic,
+    ImageToGif,     // media::convert_image_to_gif
+    ImageGeneric,   // image::convert_image
+    HeicInput,      // image::convert_heic (heic input, non-pdf target)
+    Media,          // media::convert_media
+    Data,           // data::convert_data
+    EpubToMobi,
+    MobiInput,      // document::convert_mobi
+    PdfToMobi,
+    PdfToHtml,
+    PdfToMd,
+    PdfToEpubOrMarker,
+    DocumentPandoc, // document::convert_document (md/txt/tex/typst, epub non-mobi)
+}
+
+/// Classify a single hop. Inputs MUST already be normalized.
+pub fn route_hop(from: &str, to: &str) -> Option<Hop> {
+    use Hop::*;
+    match from {
+        "png" | "jpg" | "webp" | "bmp" | "tiff" | "gif" => match to {
+            "pdf" => Some(ImageRaster),
+            "avif" => Some(ImageToAvif),
+            "heic" => Some(ImageToHeic),
+            "gif" => Some(ImageToGif),
+            "png" | "jpg" | "webp" | "bmp" | "tiff" => Some(ImageGeneric),
+            _ => None,
+        },
+        "avif" => match to {
+            "pdf" => Some(ImageRaster),
+            "heic" => Some(ImageToHeic),
+            "gif" => Some(ImageToGif),
+            "png" | "jpg" | "webp" | "bmp" | "tiff" => Some(ImageGeneric),
+            _ => None,
+        },
+        "heic" => match to {
+            "pdf" => Some(ImageRaster),
+            "jpg" | "png" | "tiff" | "gif" | "bmp" => Some(HeicInput),
+            _ => None,
+        },
+        "mp4" | "mov" | "mkv" | "webm" | "avi" | "mp3" | "aac" | "flac" | "ogg" | "wav"
+        | "opus" | "m4a" => Some(Media),
+        "json" | "yaml" | "toml" | "csv" => Some(Data),
+        "mobi" => Some(MobiInput),
+        "epub" => {
+            if to == "mobi" {
+                Some(EpubToMobi)
+            } else {
+                Some(DocumentPandoc)
+            }
+        }
+        "pdf" => match to {
+            "mobi" => Some(PdfToMobi),
+            "html" => Some(PdfToHtml),
+            "md" => Some(PdfToMd),
+            "epub" => Some(PdfToEpubOrMarker),
+            _ => None,
+        },
+        "md" | "txt" | "tex" | "typst" => Some(DocumentPandoc),
+        _ => None,
+    }
+}
+
+/// Maximum number of hops (edges) in a chain.
+pub const MAX_HOPS: usize = 6;
+
+/// Dijkstra from `from` over platform-satisfiable edges. Returns, for every
+/// reachable node, the min-cost path (as a node sequence including endpoints)
+/// whose length is within `MAX_HOPS`.
+pub fn shortest_paths(from: &str) -> HashMap<String, Vec<String>> {
+    let from = normalize_ext(from).to_string();
+
+    // adjacency: node -> Vec<(neighbor, cost)>
+    let mut adj: HashMap<&'static str, Vec<(&'static str, u32)>> = HashMap::new();
+    for e in edges() {
+        if e.cond.satisfied() {
+            adj.entry(e.from).or_default().push((e.to, e.cost));
+        }
+    }
+
+    let mut dist: HashMap<String, u32> = HashMap::new();
+    let mut prev: HashMap<String, String> = HashMap::new();
+    dist.insert(from.clone(), 0);
+
+    // min-heap on (Reverse(cost), node)
+    let mut heap: BinaryHeap<(std::cmp::Reverse<u32>, String)> = BinaryHeap::new();
+    heap.push((std::cmp::Reverse(0), from.clone()));
+
+    while let Some((std::cmp::Reverse(d), node)) = heap.pop() {
+        if d > *dist.get(&node).unwrap_or(&u32::MAX) {
+            continue;
+        }
+        if let Some(neighbors) = adj.get(node.as_str()) {
+            for &(nbr, cost) in neighbors {
+                let nd = d + cost;
+                if nd < *dist.get(nbr).unwrap_or(&u32::MAX) {
+                    dist.insert(nbr.to_string(), nd);
+                    prev.insert(nbr.to_string(), node.clone());
+                    heap.push((std::cmp::Reverse(nd), nbr.to_string()));
+                }
+            }
+        }
+    }
+
+    // reconstruct paths, dropping any that exceed MAX_HOPS
+    let mut paths: HashMap<String, Vec<String>> = HashMap::new();
+    for target in dist.keys() {
+        if *target == from {
+            continue;
+        }
+        let mut seq = vec![target.clone()];
+        let mut cur = target.clone();
+        while let Some(p) = prev.get(&cur) {
+            seq.push(p.clone());
+            cur = p.clone();
+        }
+        seq.reverse();
+        if seq.len() - 1 <= MAX_HOPS {
+            paths.insert(target.clone(), seq);
+        }
+    }
+    paths
+}
+
+/// Semantic dead-ends: (from, to) pairs that the graph structurally cannot
+/// offer even if a multi-hop path exists through intermediate nodes.
+/// Reason: CSV is an array-of-records; TOML has no top-level array syntax,
+/// so the conversion would always fail at runtime regardless of the route.
+fn is_semantically_blocked(from: &str, to: &str) -> bool {
+    matches!((from, to), ("csv", "toml"))
+}
+
+/// Min-cost path of normalized format nodes from `from_ext` to `target`,
+/// including both endpoints. `None` if unreachable, beyond `MAX_HOPS`, or
+/// semantically blocked (e.g. csv→toml has no valid TOML representation).
+pub fn find_path(from_ext: &str, target: &str) -> Option<Vec<String>> {
+    let target = normalize_ext(target).to_string();
+    let from = normalize_ext(from_ext).to_string();
+    if from == target {
+        return None;
+    }
+    if is_semantically_blocked(&from, &target) {
+        return None;
+    }
+    shortest_paths(&from).remove(&target)
 }

--- a/swift-shifter/src/converter/graph.rs
+++ b/swift-shifter/src/converter/graph.rs
@@ -1,0 +1,151 @@
+//! The format conversion graph: the single source of truth for which
+//! conversions exist, what they cost, and which converter performs them.
+//!
+//! `detect_output_formats`, the chain finder, and the per-hop executor all
+//! derive from `edges()` / `route_hop()` here — so the "must stay in sync"
+//! coupling between detection and conversion lives in exactly one place.
+
+/// Platform / capability gate on an edge.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum EdgeCond {
+    /// Always available.
+    Always,
+    /// Requires macOS (HEIC via `sips`).
+    MacOnly,
+}
+
+impl EdgeCond {
+    /// Whether this edge is usable on the current platform.
+    pub fn satisfied(self) -> bool {
+        match self {
+            EdgeCond::Always => true,
+            EdgeCond::MacOnly => cfg!(target_os = "macos"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Edge {
+    pub from: &'static str,
+    pub to: &'static str,
+    // cost is read by the Dijkstra path-finder in Task 3; suppress dead_code until then.
+    #[allow(dead_code)]
+    pub cost: u32,
+    pub cond: EdgeCond,
+}
+
+/// Collapse extension aliases to a single canonical key used by the graph.
+pub fn normalize_ext(ext: &str) -> &str {
+    match ext {
+        "jpeg" => "jpg",
+        "yml" => "yaml",
+        "tif" => "tiff",
+        "markdown" => "md",
+        "latex" => "tex",
+        "heif" => "heic",
+        other => other,
+    }
+}
+
+const IMG_RASTER: &[&str] = &["png", "jpg", "webp", "bmp", "tiff", "gif"];
+const VIDEO: &[&str] = &["mp4", "mov", "mkv", "webm", "avi"];
+const AUDIO: &[&str] = &["mp3", "aac", "flac", "ogg", "wav", "opus", "m4a"];
+
+/// Build the full edge list. Cheap; called per detection/conversion.
+pub fn edges() -> Vec<Edge> {
+    use EdgeCond::{Always, MacOnly};
+    let mut e: Vec<Edge> = Vec::new();
+    // Annotated to pin &'static str (Edge.from/to require it; inference is ambiguous otherwise).
+    let mut push = |from: &'static str, to: &'static str, cost: u32, cond: EdgeCond| {
+        e.push(Edge { from, to, cost, cond })
+    };
+
+    // ---- Raster image inputs (incl. avif) ----
+    let img_inputs: &[&str] = &["png", "jpg", "webp", "bmp", "tiff", "gif", "avif"];
+    for &from in img_inputs {
+        for &to in IMG_RASTER {
+            if to != from {
+                push(from, to, if to == "jpg" { 4 } else { 2 }, Always);
+            }
+        }
+        if from != "avif" {
+            push(from, "avif", 4, Always);
+        }
+        push(from, "heic", 4, MacOnly);
+        push(from, "pdf", 6, Always);
+    }
+
+    // ---- HEIC/HEIF input (macOS sips only) ----
+    for &to in &["jpg", "png", "tiff", "gif", "bmp"] {
+        push("heic", to, if to == "jpg" { 4 } else { 2 }, MacOnly);
+    }
+    push("heic", "pdf", 6, MacOnly);
+
+    // ---- Video & audio (ffmpeg re-encode) ----
+    for &from in VIDEO {
+        for &to in &["mp4", "mov", "mkv", "webm", "avi", "gif"] {
+            if to != from {
+                push(from, to, 4, Always);
+            }
+        }
+    }
+    for &from in AUDIO {
+        for &to in AUDIO {
+            if to != from {
+                push(from, to, 4, Always);
+            }
+        }
+    }
+
+    // ---- Data (serde, lossless-ish) ----
+    push("json", "yaml", 1, Always);
+    push("json", "toml", 1, Always);
+    push("json", "csv", 1, Always);
+    push("yaml", "json", 1, Always);
+    push("yaml", "toml", 1, Always);
+    push("yaml", "csv", 1, Always);
+    push("toml", "json", 1, Always);
+    push("toml", "yaml", 1, Always);
+    push("toml", "csv", 1, Always);
+    // csv -> toml deliberately absent: CSV is an array, TOML has no top-level array.
+    push("csv", "json", 1, Always);
+    push("csv", "yaml", 1, Always);
+
+    // ---- Documents & ebooks ----
+    // cost rule: render to pdf = 6, extract from pdf = 8, otherwise 4.
+    let doc: &[(&str, &[&str])] = &[
+        ("md", &["txt", "html", "pdf", "tex", "typst"]),
+        ("txt", &["md", "html", "pdf", "tex", "typst"]),
+        ("tex", &["md", "html", "pdf", "typst"]),
+        ("typst", &["md", "html", "pdf", "tex"]),
+        ("epub", &["pdf", "mobi", "md", "html"]),
+        ("mobi", &["epub", "pdf", "html", "md"]),
+        ("pdf", &["epub", "mobi", "html", "md"]),
+    ];
+    for &(from, tos) in doc {
+        for &to in tos {
+            let cost = if to == "pdf" {
+                6
+            } else if from == "pdf" {
+                8
+            } else {
+                4
+            };
+            push(from, to, cost, Always);
+        }
+    }
+
+    e
+}
+
+/// Direct (1-hop) target formats for a normalized input extension,
+/// filtered to edges usable on this platform. This is the body of
+/// `detect_output_formats`.
+pub fn direct_targets(from_ext: &str) -> Vec<String> {
+    let from = normalize_ext(from_ext);
+    edges()
+        .into_iter()
+        .filter(|e| e.from == from && e.cond.satisfied())
+        .map(|e| e.to.to_string())
+        .collect()
+}

--- a/swift-shifter/src/converter/graph.rs
+++ b/swift-shifter/src/converter/graph.rs
@@ -260,10 +260,13 @@ pub fn shortest_paths(from: &str) -> HashMap<String, Vec<String>> {
         }
     }
 
-    // reconstruct paths, dropping any that exceed MAX_HOPS
+    // reconstruct paths, dropping any that exceed MAX_HOPS or are semantically blocked
     let mut paths: HashMap<String, Vec<String>> = HashMap::new();
     for target in dist.keys() {
         if *target == from {
+            continue;
+        }
+        if is_semantically_blocked(&from, target) {
             continue;
         }
         let mut seq = vec![target.clone()];

--- a/swift-shifter/src/converter/graph.rs
+++ b/swift-shifter/src/converter/graph.rs
@@ -149,6 +149,7 @@ pub fn direct_targets(from_ext: &str) -> Vec<String> {
 }
 
 use std::collections::{BinaryHeap, HashMap};
+use std::path::Path;
 
 /// Which converter performs a single (from,to) hop. Mirrors the dispatch in
 /// `converter::run_single_hop`. `route_hop` returns `Some` iff the pair is
@@ -304,4 +305,49 @@ pub fn find_path(from_ext: &str, target: &str) -> Option<Vec<String>> {
         return None;
     }
     shortest_paths(&from).remove(&target)
+}
+
+#[derive(serde::Serialize, Debug)]
+pub struct ChainedTarget {
+    pub format: String,
+    /// Full node sequence including source and target, e.g. ["png","pdf","epub","mobi"].
+    pub route: Vec<String>,
+    /// Number of hops (edges) = route.len() - 1.
+    pub hops: usize,
+}
+
+#[derive(serde::Serialize, Debug)]
+pub struct DetectResult {
+    pub direct: Vec<String>,
+    pub chained: Vec<ChainedTarget>,
+}
+
+/// Direct + multi-hop reachable targets for a file path. Errors if the input
+/// extension has no outgoing edges at all (unsupported type).
+pub fn detect_with_chains(path: &str) -> Result<DetectResult, String> {
+    let ext = Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+    let from = normalize_ext(&ext);
+
+    let direct = direct_targets(&ext);
+    if direct.is_empty() {
+        return Err(format!("Unsupported file type: .{ext}"));
+    }
+
+    let mut chained: Vec<ChainedTarget> = shortest_paths(from)
+        .into_iter()
+        .filter(|(fmt, seq)| seq.len() > 2 && !direct.contains(fmt))
+        .map(|(fmt, seq)| ChainedTarget {
+            hops: seq.len() - 1,
+            route: seq,
+            format: fmt,
+        })
+        .collect();
+    // Stable, predictable order for the UI: fewest hops first, then name.
+    chained.sort_by(|a, b| a.hops.cmp(&b.hops).then_with(|| a.format.cmp(&b.format)));
+
+    Ok(DetectResult { direct, chained })
 }

--- a/swift-shifter/src/converter/mod.rs
+++ b/swift-shifter/src/converter/mod.rs
@@ -1,5 +1,6 @@
 pub mod data;
 pub mod document;
+pub mod graph;
 pub mod image;
 pub mod media;
 
@@ -9,7 +10,8 @@ use std::path::Path;
 
 use crate::config::Config;
 
-/// Return the list of valid output format strings for a given input file path.
+/// Return the list of valid DIRECT output format strings for a given input path.
+/// Derived from the edge table in `graph.rs` (single source of truth).
 pub fn detect_output_formats(path: &str) -> Result<Vec<String>, String> {
     let ext = Path::new(path)
         .extension()
@@ -17,45 +19,11 @@ pub fn detect_output_formats(path: &str) -> Result<Vec<String>, String> {
         .unwrap_or("")
         .to_lowercase();
 
-    let formats: &[&str] = match ext.as_str() {
-        // Images
-        "png" | "jpg" | "jpeg" | "webp" | "bmp" | "tiff" | "tif" | "gif" | "avif" => &[
-            "png", "jpg", "webp", "avif", "gif", "bmp", "tiff", "heic", "pdf",
-        ],
-        // HEIC — macOS sips only; no WebP/AVIF output via sips
-        "heic" | "heif" => &["jpg", "png", "tiff", "gif", "bmp", "pdf"],
-        // Video
-        "mp4" | "mov" | "mkv" | "webm" | "avi" => &["mp4", "mov", "mkv", "webm", "avi", "gif"],
-        // Audio
-        "mp3" | "aac" | "flac" | "ogg" | "wav" | "opus" | "m4a" => {
-            &["mp3", "aac", "flac", "ogg", "wav", "opus", "m4a"]
-        }
-        // Data
-        "json" => &["yaml", "toml", "csv"],
-        "yaml" | "yml" => &["json", "toml", "csv"],
-        "toml" => &["json", "yaml", "csv"],
-        // CSV is always an array of records; TOML has no top-level array-of-tables,
-        // so csv → toml can never succeed. Don't offer it.
-        "csv" => &["json", "yaml"],
-        // Documents (pandoc)
-        "md" | "markdown" => &["txt", "html", "pdf", "tex", "typst"],
-        "txt" => &["md", "html", "pdf", "tex", "typst"],
-        "tex" | "latex" => &["md", "html", "pdf", "typst"],
-        "typst" => &["md", "html", "pdf", "tex"],
-        "epub" => &["pdf", "mobi", "md", "html"],
-        "mobi" => &["epub", "pdf", "html", "md"],
-        "pdf" => &["epub", "mobi", "html", "md"],
-        _ => return Err(format!("Unsupported file type: .{ext}")),
-    };
-
-    let is_jpeg_input = ext == "jpg" || ext == "jpeg";
-    Ok(formats
-        .iter()
-        .filter(|&&f| {
-            f != ext.as_str() && !(is_jpeg_input && (f == "jpg" || f == "jpeg"))
-        })
-        .map(|s| s.to_string())
-        .collect())
+    let targets = graph::direct_targets(&ext);
+    if targets.is_empty() {
+        return Err(format!("Unsupported file type: .{ext}"));
+    }
+    Ok(targets)
 }
 
 pub async fn convert_file(

--- a/swift-shifter/src/converter/mod.rs
+++ b/swift-shifter/src/converter/mod.rs
@@ -26,85 +26,119 @@ pub fn detect_output_formats(path: &str) -> Result<Vec<String>, String> {
     Ok(targets)
 }
 
+/// Execute exactly one conversion hop. `from`/`to` MUST be normalized.
+/// `out_dir` is where THIS hop writes (a temp dir for intermediate hops).
+async fn run_single_hop(
+    app: &tauri::AppHandle,
+    path: &str,
+    from: &str,
+    to: &str,
+    out_dir: Option<&str>,
+    config: &Config,
+) -> Result<String, String> {
+    use graph::Hop;
+    let hop = graph::route_hop(from, to)
+        .ok_or_else(|| format!("No converter handles .{from} → {to}"))?;
+
+    match hop {
+        Hop::ImageRaster => document::convert_image_to_pdf(app, path, out_dir).await,
+        Hop::ImageToAvif => image::convert_to_avif(path, config.avif_quality, out_dir),
+        Hop::ImageToHeic => image::convert_to_heic(path, out_dir),
+        Hop::ImageToGif => media::convert_image_to_gif(app, path, out_dir).await,
+        Hop::ImageGeneric => image::convert_image(path, to, config.jpeg_quality, out_dir),
+        Hop::HeicInput => image::convert_heic(path, to, out_dir),
+        Hop::Media => media::convert_media(app, path, to, out_dir).await,
+        Hop::Data => data::convert_data(path, to, out_dir),
+        Hop::EpubToMobi => document::convert_epub_to_mobi(app, path, out_dir).await,
+        Hop::MobiInput => document::convert_mobi(app, path, to, out_dir).await,
+        Hop::DocumentPandoc => document::convert_document(app, path, to, out_dir).await,
+        Hop::PdfToMobi => {
+            let llm = pdf_llm_cfg(config);
+            document::convert_pdf_to_mobi(app, path, out_dir, config.use_marker_pdf, llm).await
+        }
+        Hop::PdfToHtml => document::convert_pdf_to_html(app, path, out_dir).await,
+        Hop::PdfToMd => {
+            let llm = pdf_llm_cfg(config);
+            document::convert_pdf_to_md(app, path, out_dir, config.use_marker_pdf, llm).await
+        }
+        Hop::PdfToEpubOrMarker => {
+            let llm = pdf_llm_cfg(config);
+            if config.use_marker_pdf && document::marker_available() {
+                document::convert_pdf_with_marker(app, path, out_dir, llm).await
+            } else {
+                document::convert_pdf_to_epub(app, path, out_dir, llm).await
+            }
+        }
+    }
+}
+
+fn pdf_llm_cfg(config: &Config) -> document::LlmCfg {
+    document::LlmCfg {
+        enabled: config.use_local_llm,
+        model: config.local_llm_model.clone(),
+        url: config.local_llm_url.clone(),
+    }
+}
+
+/// Convert `path` to `target_format`, chaining hops through a temp dir when no
+/// direct conversion exists. Only the final artifact lands in `config.output_dir`.
 pub async fn convert_file(
     app: &tauri::AppHandle,
     path: &str,
     target_format: &str,
     config: &Config,
 ) -> Result<String, String> {
+    use tauri::Emitter;
+
     let ext = Path::new(path)
         .extension()
         .and_then(|e| e.to_str())
         .unwrap_or("")
         .to_lowercase();
 
-    let out_dir = config.output_dir.as_deref();
+    let seq = graph::find_path(&ext, target_format)
+        .ok_or_else(|| format!("No conversion path from .{ext} to {target_format}"))?;
 
-    match ext.as_str() {
-        "png" | "jpg" | "jpeg" | "webp" | "bmp" | "tiff" | "tif" | "gif" => {
-            if target_format == "pdf" {
-                document::convert_image_to_pdf(app, path, out_dir).await
-            } else if target_format == "avif" {
-                image::convert_to_avif(path, config.avif_quality, out_dir)
-            } else if target_format == "heic" {
-                image::convert_to_heic(path, out_dir)
-            } else if target_format == "gif" {
-                media::convert_image_to_gif(app, path, out_dir).await
-            } else {
-                image::convert_image(path, target_format, config.jpeg_quality, out_dir)
-            }
-        }
-        "avif" => {
-            if target_format == "pdf" {
-                document::convert_image_to_pdf(app, path, out_dir).await
-            } else if target_format == "heic" {
-                image::convert_to_heic(path, out_dir)
-            } else if target_format == "gif" {
-                media::convert_image_to_gif(app, path, out_dir).await
-            } else {
-                image::convert_image(path, target_format, config.jpeg_quality, out_dir)
-            }
-        }
-        "heic" | "heif" => {
-            if target_format == "pdf" {
-                document::convert_image_to_pdf(app, path, out_dir).await
-            } else {
-                image::convert_heic(path, target_format, out_dir)
-            }
-        }
-        "mp4" | "mov" | "mkv" | "webm" | "avi" | "mp3" | "aac" | "flac" | "ogg" | "wav"
-        | "opus" | "m4a" => media::convert_media(app, path, target_format, out_dir).await,
-        "json" | "yaml" | "yml" | "toml" | "csv" => {
-            data::convert_data(path, target_format, out_dir)
-        }
-        "mobi" => document::convert_mobi(app, path, target_format, out_dir).await,
-        "epub" => match target_format {
-            "mobi" => document::convert_epub_to_mobi(app, path, out_dir).await,
-            _ => document::convert_document(app, path, target_format, out_dir).await,
-        },
-        "pdf" => {
-            let llm = document::LlmCfg {
-                enabled: config.use_local_llm,
-                model:   config.local_llm_model.clone(),
-                url:     config.local_llm_url.clone(),
-            };
-            match target_format {
-                "mobi" => document::convert_pdf_to_mobi(app, path, out_dir, config.use_marker_pdf, llm).await,
-                "html" => document::convert_pdf_to_html(app, path, out_dir).await,
-                "md" => document::convert_pdf_to_md(app, path, out_dir, config.use_marker_pdf, llm).await,
-                _ => {
-                    if config.use_marker_pdf && document::marker_available() {
-                        document::convert_pdf_with_marker(app, path, out_dir, llm).await
-                    } else {
-                        document::convert_pdf_to_epub(app, path, out_dir, llm).await
-                    }
-                }
-            }
-        },
-        "md" | "markdown" | "txt" | "tex" | "latex" | "typst" => {
-            document::convert_document(app, path, target_format, out_dir).await
-        }
-        _ => Err(format!("Unsupported input format: .{ext}")),
+    // Direct conversion: behave exactly as before.
+    if seq.len() == 2 {
+        return run_single_hop(app, path, &seq[0], &seq[1], config.output_dir.as_deref(), config)
+            .await;
     }
+
+    // Multi-hop: run through a temp dir; only the last hop writes to output_dir.
+    let tmp = tempfile::Builder::new()
+        .prefix("swift-shifter-chain-")
+        .tempdir()
+        .map_err(|e| format!("Failed to create temp dir: {e}"))?;
+    let tmp_str = tmp.path().to_str().ok_or("Temp path is not valid UTF-8")?;
+
+    let total = seq.len() - 1;
+    let mut current = path.to_string();
+    for (i, win) in seq.windows(2).enumerate() {
+        // Overall progress keyed to the ORIGINAL path (UI ignores temp-path emits).
+        let pct = (i as f64 / total as f64) * 100.0;
+        app.emit(
+            "convert:progress",
+            serde_json::json!({ "path": path, "percent": pct }),
+        )
+        .ok();
+
+        let is_last = i == total - 1;
+        let out_dir = if is_last {
+            config.output_dir.as_deref()
+        } else {
+            Some(tmp_str)
+        };
+        current = run_single_hop(app, &current, &win[0], &win[1], out_dir, config).await?;
+    }
+
+    app.emit(
+        "convert:progress",
+        serde_json::json!({ "path": path, "percent": 100.0 }),
+    )
+    .ok();
+
+    // `tmp` drops here, removing all intermediates; the final file is in output_dir.
+    Ok(current)
 }
 mod tests;

--- a/swift-shifter/src/converter/tests.rs
+++ b/swift-shifter/src/converter/tests.rs
@@ -136,4 +136,57 @@ mod tests {
         // HEIC input has only MacOnly edges, so off-macOS it is an unsupported type.
         assert!(d("/x.heic").is_err());
     }
+
+    #[test]
+    fn test_find_path_direct_is_two_nodes() {
+        let p = crate::converter::graph::find_path("json", "yaml").unwrap();
+        assert_eq!(p, vec!["json".to_string(), "yaml".to_string()]);
+    }
+
+    #[test]
+    fn test_find_path_multi_hop_png_to_mobi() {
+        // png has no direct edge to mobi; must go through pdf then an ebook tool.
+        let p = crate::converter::graph::find_path("png", "mobi").unwrap();
+        assert!(p.len() > 2, "expected a chain, got {p:?}");
+        assert_eq!(p.first().unwrap(), &"png");
+        assert_eq!(p.last().unwrap(), &"mobi");
+        for w in p.windows(2) {
+            assert!(
+                crate::converter::graph::route_hop(&w[0], &w[1]).is_some(),
+                "hop {:?}->{:?} not routable",
+                w[0], w[1]
+            );
+        }
+    }
+
+    #[test]
+    fn test_find_path_normalizes_aliases() {
+        let p = crate::converter::graph::find_path("jpeg", "png").unwrap();
+        assert_eq!(p, vec!["jpg".to_string(), "png".to_string()]);
+    }
+
+    #[test]
+    fn test_find_path_unreachable_returns_none() {
+        assert!(crate::converter::graph::find_path("csv", "toml").is_none());
+    }
+
+    #[test]
+    fn test_find_path_prefers_cheaper_route() {
+        let p = crate::converter::graph::find_path("png", "tiff").unwrap();
+        assert_eq!(p, vec!["png".to_string(), "tiff".to_string()]);
+    }
+
+    #[test]
+    fn test_route_hop_covers_every_satisfiable_edge() {
+        // The core guarantee: nothing the table offers is unhandled by the dispatcher.
+        for e in crate::converter::graph::edges() {
+            if e.cond.satisfied() {
+                assert!(
+                    crate::converter::graph::route_hop(e.from, e.to).is_some(),
+                    "edge {}->{} is offered but route_hop returns None",
+                    e.from, e.to
+                );
+            }
+        }
+    }
 }

--- a/swift-shifter/src/converter/tests.rs
+++ b/swift-shifter/src/converter/tests.rs
@@ -69,4 +69,59 @@ mod tests {
     fn test_find_typst_binary_does_not_panic() {
         let _ = crate::converter::document::find_typst_binary();
     }
+
+    /// Locks the exact direct-output surface before the graph refactor.
+    /// macOS values (HEIC offered) — see platform test for the non-macOS delta.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_detect_output_formats_snapshot() {
+        use crate::converter::detect_output_formats as d;
+        let cases: &[(&str, &[&str])] = &[
+            ("/x.png",  &["jpg","webp","avif","gif","bmp","tiff","heic","pdf"]),
+            ("/x.jpg",  &["png","webp","avif","gif","bmp","tiff","heic","pdf"]),
+            ("/x.jpeg", &["png","webp","avif","gif","bmp","tiff","heic","pdf"]),
+            ("/x.webp", &["png","jpg","avif","gif","bmp","tiff","heic","pdf"]),
+            ("/x.gif",  &["png","jpg","webp","avif","bmp","tiff","heic","pdf"]),
+            ("/x.bmp",  &["png","jpg","webp","avif","gif","tiff","heic","pdf"]),
+            ("/x.tiff", &["png","jpg","webp","avif","gif","bmp","heic","pdf"]),
+            ("/x.tif",  &["png","jpg","webp","avif","gif","bmp","tiff","heic","pdf"]),
+            ("/x.avif", &["png","jpg","webp","gif","bmp","tiff","heic","pdf"]),
+            ("/x.heic", &["jpg","png","tiff","gif","bmp","pdf"]),
+            ("/x.heif", &["jpg","png","tiff","gif","bmp","pdf"]),
+            ("/x.mp4",  &["mov","mkv","webm","avi","gif"]),
+            ("/x.mov",  &["mp4","mkv","webm","avi","gif"]),
+            ("/x.mkv",  &["mp4","mov","webm","avi","gif"]),
+            ("/x.webm", &["mp4","mov","mkv","avi","gif"]),
+            ("/x.avi",  &["mp4","mov","mkv","webm","gif"]),
+            ("/x.mp3",  &["aac","flac","ogg","wav","opus","m4a"]),
+            ("/x.aac",  &["mp3","flac","ogg","wav","opus","m4a"]),
+            ("/x.flac", &["mp3","aac","ogg","wav","opus","m4a"]),
+            ("/x.ogg",  &["mp3","aac","flac","wav","opus","m4a"]),
+            ("/x.wav",  &["mp3","aac","flac","ogg","opus","m4a"]),
+            ("/x.opus", &["mp3","aac","flac","ogg","wav","m4a"]),
+            ("/x.m4a",  &["mp3","aac","flac","ogg","wav","opus"]),
+            ("/x.json", &["yaml","toml","csv"]),
+            ("/x.yaml", &["json","toml","csv"]),
+            ("/x.yml",  &["json","toml","csv"]),
+            ("/x.toml", &["json","yaml","csv"]),
+            ("/x.csv",  &["json","yaml"]),
+            ("/x.md",   &["txt","html","pdf","tex","typst"]),
+            ("/x.markdown", &["txt","html","pdf","tex","typst"]),
+            ("/x.txt",  &["md","html","pdf","tex","typst"]),
+            ("/x.tex",  &["md","html","pdf","typst"]),
+            ("/x.latex",&["md","html","pdf","typst"]),
+            ("/x.typst",&["md","html","pdf","tex"]),
+            ("/x.epub", &["pdf","mobi","md","html"]),
+            ("/x.mobi", &["epub","pdf","html","md"]),
+            ("/x.pdf",  &["epub","mobi","html","md"]),
+        ];
+        for (path, expected) in cases {
+            let mut got = d(path).unwrap();
+            let mut want: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
+            got.sort();
+            want.sort();
+            assert_eq!(got, want, "direct formats for {path} changed");
+        }
+        assert!(d("/x.xyz").is_err(), "unknown extension must error");
+    }
 }

--- a/swift-shifter/src/converter/tests.rs
+++ b/swift-shifter/src/converter/tests.rs
@@ -189,4 +189,28 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_detect_with_chains_png_offers_chained_mobi() {
+        let r = crate::converter::graph::detect_with_chains("/x.png").unwrap();
+        // direct still includes a 1-hop target
+        assert!(r.direct.contains(&"pdf".to_string()));
+        // mobi is NOT direct from png
+        assert!(!r.direct.contains(&"mobi".to_string()));
+        // ...but appears as a chained target with a route through pdf
+        let mobi = r.chained.iter().find(|c| c.format == "mobi")
+            .expect("mobi should be a chained target for png");
+        assert!(mobi.hops >= 2);
+        assert_eq!(mobi.route.first().unwrap(), "png");
+        assert_eq!(mobi.route.last().unwrap(), "mobi");
+        // chained never repeats a direct target
+        for c in &r.chained {
+            assert!(!r.direct.contains(&c.format), "{} is both direct and chained", c.format);
+        }
+    }
+
+    #[test]
+    fn test_detect_with_chains_unknown_errors() {
+        assert!(crate::converter::graph::detect_with_chains("/x.xyz").is_err());
+    }
 }

--- a/swift-shifter/src/converter/tests.rs
+++ b/swift-shifter/src/converter/tests.rs
@@ -84,7 +84,9 @@ mod tests {
             ("/x.gif",  &["png","jpg","webp","avif","bmp","tiff","heic","pdf"]),
             ("/x.bmp",  &["png","jpg","webp","avif","gif","tiff","heic","pdf"]),
             ("/x.tiff", &["png","jpg","webp","avif","gif","bmp","heic","pdf"]),
-            ("/x.tif",  &["png","jpg","webp","avif","gif","bmp","tiff","heic","pdf"]),
+            // .tif normalizes to tiff in the graph, so the pointless tif->tiff
+            // identity conversion is no longer offered (intentional delta).
+            ("/x.tif",  &["png","jpg","webp","avif","gif","bmp","heic","pdf"]),
             ("/x.avif", &["png","jpg","webp","gif","bmp","tiff","heic","pdf"]),
             ("/x.heic", &["jpg","png","tiff","gif","bmp","pdf"]),
             ("/x.heif", &["jpg","png","tiff","gif","bmp","pdf"]),

--- a/swift-shifter/src/converter/tests.rs
+++ b/swift-shifter/src/converter/tests.rs
@@ -126,4 +126,14 @@ mod tests {
         }
         assert!(d("/x.xyz").is_err(), "unknown extension must error");
     }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn test_heic_absent_off_macos() {
+        use crate::converter::detect_output_formats as d;
+        // HEIC output is offered only on macOS (sips).
+        assert!(!d("/x.png").unwrap().contains(&"heic".to_string()));
+        // HEIC input has only MacOnly edges, so off-macOS it is an unsupported type.
+        assert!(d("/x.heic").is_err());
+    }
 }

--- a/swift-shifter/src/main.rs
+++ b/swift-shifter/src/main.rs
@@ -287,8 +287,8 @@ async fn install_update(app: tauri::AppHandle) -> Result<(), String> {
 }
 
 #[tauri::command]
-async fn detect_format(path: String) -> Result<Vec<String>, String> {
-    converter::detect_output_formats(&path)
+async fn detect_format(path: String) -> Result<converter::graph::DetectResult, String> {
+    converter::graph::detect_with_chains(&path)
 }
 
 #[tauri::command]

--- a/swift-shifter/tests/chain_cli.rs
+++ b/swift-shifter/tests/chain_cli.rs
@@ -1,0 +1,79 @@
+//! End-to-end test of multi-hop chaining through the real CLI.
+//! Skipped when the tools the chain needs are unavailable (e.g. CI without
+//! pandoc / typst / Calibre).
+
+use std::process::Command;
+
+/// True if `doctor` reports the named tool with a leading "✓".
+fn tool_present(doctor_stdout: &str, name: &str) -> bool {
+    doctor_stdout
+        .lines()
+        .any(|l| l.starts_with('\u{2713}') && l.contains(name))
+}
+
+#[test]
+fn png_to_mobi_chain_produces_file() {
+    // 1. Ask the CLI which tools exist.
+    let doctor = Command::new(env!("CARGO_BIN_EXE_swift-shifter"))
+        .arg("doctor")
+        .output()
+        .expect("failed to run doctor");
+    let report = String::from_utf8_lossy(&doctor.stdout);
+
+    // png -> pdf needs pandoc + typst; pdf -> mobi needs Calibre (ebook-convert).
+    let needed = ["pandoc", "typst", "ebook-convert"];
+    let missing: Vec<&str> = needed
+        .iter()
+        .copied()
+        .filter(|t| !tool_present(&report, t))
+        .collect();
+    if !missing.is_empty() {
+        eprintln!(
+            "SKIP: png->mobi chain e2e; missing tools: {missing:?}"
+        );
+        return;
+    }
+
+    // 2. Make a tiny real PNG in a temp dir.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let png = dir.path().join("tiny.png");
+    write_tiny_png(&png);
+
+    // 3. Run the chain via the CLI: `convert mobi tiny.png`, output into the temp dir.
+    let out = Command::new(env!("CARGO_BIN_EXE_swift-shifter"))
+        .args([
+            "--output-dir",
+            dir.path().to_str().unwrap(),
+            "convert",
+            "mobi",
+            png.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to run convert");
+
+    assert!(
+        out.status.success(),
+        "convert failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // 4. The CLI prints the output path on success; it must exist and be non-empty.
+    let printed = String::from_utf8_lossy(&out.stdout);
+    let produced = printed.trim().lines().last().unwrap_or("").trim();
+    assert!(!produced.is_empty(), "no output path printed");
+    let meta = std::fs::metadata(produced).expect("output file missing");
+    assert!(meta.len() > 0, "output file is empty");
+}
+
+/// Write a minimal valid 1x1 PNG.
+fn write_tiny_png(path: &std::path::Path) {
+    const PNG: &[u8] = &[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F,
+        0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00,
+        0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+        0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ];
+    std::fs::write(path, PNG).expect("write png");
+}

--- a/swift-shifter/tests/chain_cli.rs
+++ b/swift-shifter/tests/chain_cli.rs
@@ -1,6 +1,6 @@
 //! End-to-end test of multi-hop chaining through the real CLI.
 //! Skipped when the tools the chain needs are unavailable (e.g. CI without
-//! pandoc / typst / Calibre).
+//! pandoc / typst / pymupdf4llm).
 
 use std::process::Command;
 
@@ -12,7 +12,7 @@ fn tool_present(doctor_stdout: &str, name: &str) -> bool {
 }
 
 #[test]
-fn png_to_mobi_chain_produces_file() {
+fn png_to_html_chain_produces_file() {
     // 1. Ask the CLI which tools exist.
     let doctor = Command::new(env!("CARGO_BIN_EXE_swift-shifter"))
         .arg("doctor")
@@ -20,32 +20,32 @@ fn png_to_mobi_chain_produces_file() {
         .expect("failed to run doctor");
     let report = String::from_utf8_lossy(&doctor.stdout);
 
-    // png -> pdf needs pandoc + typst; pdf -> mobi needs Calibre (ebook-convert).
-    let needed = ["pandoc", "typst", "ebook-convert"];
+    // The chain is png -> pdf -> html (png has no direct html edge):
+    //   png -> pdf  needs pandoc + a typst PDF engine,
+    //   pdf -> html needs pymupdf4llm (then pandoc).
+    let needed = ["pandoc", "typst", "pymupdf4llm"];
     let missing: Vec<&str> = needed
         .iter()
         .copied()
         .filter(|t| !tool_present(&report, t))
         .collect();
     if !missing.is_empty() {
-        eprintln!(
-            "SKIP: png->mobi chain e2e; missing tools: {missing:?}"
-        );
+        eprintln!("SKIP: png->html chain e2e; missing tools: {missing:?}");
         return;
     }
 
-    // 2. Make a tiny real PNG in a temp dir.
+    // 2. Make a tiny real PNG in a temp dir that doubles as the output dir.
     let dir = tempfile::tempdir().expect("tempdir");
     let png = dir.path().join("tiny.png");
     write_tiny_png(&png);
 
-    // 3. Run the chain via the CLI: `convert mobi tiny.png`, output into the temp dir.
+    // 3. Run the chain via the CLI: `convert html tiny.png`, output into the temp dir.
     let out = Command::new(env!("CARGO_BIN_EXE_swift-shifter"))
         .args([
             "--output-dir",
             dir.path().to_str().unwrap(),
             "convert",
-            "mobi",
+            "html",
             png.to_str().unwrap(),
         ])
         .output()
@@ -62,8 +62,18 @@ fn png_to_mobi_chain_produces_file() {
     let printed = String::from_utf8_lossy(&out.stdout);
     let produced = printed.trim().lines().last().unwrap_or("").trim();
     assert!(!produced.is_empty(), "no output path printed");
+    assert!(produced.ends_with(".html"), "expected .html output, got {produced}");
     let meta = std::fs::metadata(produced).expect("output file missing");
     assert!(meta.len() > 0, "output file is empty");
+
+    // 5. The intermediate PDF must NOT leak into the output dir — only the final
+    //    artifact lands there; intermediates live in (and die with) a temp dir.
+    let leaked: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "pdf"))
+        .collect();
+    assert!(leaked.is_empty(), "intermediate pdf leaked into output dir: {leaked:?}");
 }
 
 /// Write a minimal valid 1x1 PNG.

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -15,10 +15,20 @@ interface InstallLogPayload {
   phase: string;
 }
 
+interface ChainedTarget {
+  format: string;
+  route: string[];
+  hops: number;
+}
+interface DetectResult {
+  direct: string[];
+  chained: ChainedTarget[];
+}
+
 interface FileEntry {
   path: string;
   name: string;
-  formats: string[];
+  formats: DetectResult;
   el: HTMLElement;
 }
 
@@ -295,9 +305,9 @@ async function addFile(path: string): Promise<void> {
     }
   }
 
-  let formats: string[];
+  let formats: DetectResult;
   try {
-    formats = await invoke<string[]>("detect_format", { path });
+    formats = await invoke<DetectResult>("detect_format", { path });
   } catch (err) {
     showInlineError(path, String(err));
     return;
@@ -366,7 +376,7 @@ function showInstallPanel(title: string, subtitle = ""): void {
 function buildFileItem(
   path: string,
   name: string,
-  formats: string[],
+  formats: DetectResult,
 ): HTMLElement {
   const item = document.createElement("div");
   item.className = "file-item";
@@ -391,14 +401,54 @@ function buildFileItem(
 
   const btnRow = document.createElement("div");
   btnRow.className = "format-buttons";
-  for (const fmt of formats) {
+  for (const fmt of formats.direct) {
     const btn = document.createElement("button");
     btn.className = "fmt-btn";
     btn.textContent = fmt;
     btn.addEventListener("click", () => startConversion(path, fmt, item));
     btnRow.appendChild(btn);
   }
-  item.appendChild(btnRow);
+
+  // "…" expander reveals chained (multi-hop) targets.
+  if (formats.chained.length > 0) {
+    const moreBtn = document.createElement("button");
+    moreBtn.className = "fmt-btn fmt-more";
+    moreBtn.textContent = "…";
+    moreBtn.title = "More formats via conversion chains";
+
+    const chainedRow = document.createElement("div");
+    chainedRow.className = "format-buttons format-chained";
+    chainedRow.hidden = true;
+
+    for (const c of formats.chained) {
+      const btn = document.createElement("button");
+      btn.className = "fmt-btn fmt-chained";
+      const via = c.route.slice(1, -1).join("→");
+      const fmtName = document.createElement("span");
+      fmtName.className = "fmt-name";
+      fmtName.textContent = c.format;
+      const fmtVia = document.createElement("span");
+      fmtVia.className = "fmt-via";
+      fmtVia.textContent = `via ${via}`;
+      btn.appendChild(fmtName);
+      btn.appendChild(fmtVia);
+      btn.title = `${c.route.join(" → ")}  (${c.hops} hops)`;
+      btn.addEventListener("click", () => startConversion(path, c.format, item));
+      chainedRow.appendChild(btn);
+    }
+
+    moreBtn.addEventListener("click", () => {
+      chainedRow.hidden = !chainedRow.hidden;
+      moreBtn.classList.toggle("active", !chainedRow.hidden);
+    });
+
+    btnRow.appendChild(moreBtn);
+    item.appendChild(btnRow);
+    item.appendChild(chainedRow);
+  } else {
+    item.appendChild(btnRow);
+  }
+
   return item;
 }
 
@@ -1076,7 +1126,7 @@ function updateBatchToolbar(): void {
   fileList.querySelector(".batch-toolbar")?.remove();
   if (files.size < 2) return;
 
-  const allFormats = Array.from(files.values()).map((e) => new Set(e.formats));
+  const allFormats = Array.from(files.values()).map((e) => new Set(e.formats.direct));
   const intersection = allFormats.reduce(
     (acc, set) => new Set([...acc].filter((f) => set.has(f))),
   );
@@ -1104,7 +1154,7 @@ function updateBatchToolbar(): void {
 
 async function startBatchConversion(targetFormat: string): Promise<void> {
   const entries = Array.from(files.values()).filter((e) =>
-    e.formats.includes(targetFormat),
+    e.formats.direct.includes(targetFormat),
   );
   if (entries.length === 0) return;
 

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -364,6 +364,29 @@ body {
     cursor: default;
 }
 
+.fmt-more {
+    font-weight: 600;
+}
+.fmt-more.active {
+    background: var(--accent, #3b82f6);
+    color: #fff;
+}
+.format-chained {
+    margin-top: 6px;
+    padding-top: 6px;
+    border-top: 1px solid var(--border, rgba(128, 128, 128, 0.25));
+}
+.fmt-chained {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
+    line-height: 1.15;
+}
+.fmt-chained .fmt-via {
+    font-size: 0.7em;
+    opacity: 0.6;
+}
+
 /* ─── Progress ────────────────────────────────────────────────────────── */
 .progress-row {
     display: flex;

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -376,6 +376,11 @@ body {
     padding-top: 6px;
     border-top: 1px solid var(--border, rgba(128, 128, 128, 0.25));
 }
+/* Override UA [hidden]{display:none} — author .format-buttons display:flex
+   would otherwise win and keep the collapsed chain row visible. */
+.format-chained[hidden] {
+    display: none;
+}
 .fmt-chained {
     display: inline-flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary

Turns Swift Shifter into a **universal converter**: if a chain of real conversions reaches a target (e.g. `png → pdf → epub → mobi`), it's now offered and executed. A single **format graph** becomes the source of truth, eliminating the long-standing "`detect_output_formats` and `convert_file` must stay in sync" coupling.

- **`converter/graph.rs` — one authoritative edge table** (`Edge { from, to, cost, cond }`). `detect_output_formats` now derives from it (`direct_targets`), so detection can't drift from the dispatcher.
- **Weighted shortest path** (`find_path`, Dijkstra over edge `cost`, capped at `MAX_HOPS = 6`) picks the cheapest chain; lossless container swaps are cheap, rasterize/extract steps cost more.
- **`route_hop` classifier + exhaustive `Hop` dispatch** in `run_single_hop`. A property test (`test_route_hop_covers_every_satisfiable_edge`) + compile-time exhaustiveness **structurally guarantee** every offered edge is handled.
- **`convert_file` is now a chain driver**: multi-hop conversions stage intermediates in a `tempfile::TempDir` (auto-cleaned) and write only the final artifact to the output dir, emitting overall `convert:progress`. Direct conversions behave exactly as before.
- **UI "…" expander**: `detect_format` now returns `DetectResult { direct, chained }`; chained targets appear behind a `…` toggle, each labelled with its route (e.g. `mobi · via pdf`).

### Intentional deltas from prior behavior
- `.tif` no longer offers the pointless `tiff` (TIFF→TIFF) identity conversion — `normalize_ext` collapses the alias.
- `csv → toml` stays blocked (`is_semantically_blocked`) even though `csv→json→toml` exists structurally, because a top-level array has no TOML form.
- HEIC edges are now `MacOnly`, so off-macOS they're simply absent instead of offered-then-failing.

## Test Plan
- [x] `cargo test -- --test-threads=1` — 95 unit + 1 integration test pass (clipboard tests need single-thread, pre-existing).
- [x] Snapshot test proves the **direct** format surface is unchanged on macOS.
- [x] `route_hop` coverage property test passes (no offered edge is unhandled).
- [x] Pathfinding unit tests: direct = 2 nodes, multi-hop `png→mobi`, alias normalization, unreachable → `None`, cheaper route wins, hop cap.
- [x] **Real end-to-end multi-hop run**: `png → pdf → html` via the CLI produces a non-empty `.html` and leaves **no** intermediate PDF in the output dir (temp-dir cleanup verified). The `tests/chain_cli.rs` e2e is tool-gated (pandoc + typst + pymupdf4llm) and runs wherever those are present.
- [x] `cargo clippy` clean on all changed files; `npm run build` (tsc + vite) clean.

## Follow-up (out of scope)
Pathfinding does not yet check **runtime tool availability** — a chain whose external tool is missing can still be offered and fail at execution (same as today). Tool-aware pruning is a planned next step.